### PR TITLE
Do not load modules from unsafe locations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+branches:
+  except:
+    - /^issue\d+/
+    - /^gh\d+/
+language: perl
+matrix:
+   fast_finish: true
+#   allow_failures:
+#     - perl: "5.12"
+#     - perl: "5.10"
+env:
+  global:
+    - PERL_USE_UNSAFE_INC=0
+    - AUTHOR_TESTING=1
+    - AUTOMATED_TESTING=1
+    - RELEASE_TESTING=1
+perl:
+  - "5.28"
+  - "5.26"
+  - "5.24"
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"
+script:
+  - perl Makefile.PL && make test
+

--- a/bin/largeprimes
+++ b/bin/largeprimes
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -sI.. -I../lib/ -Ilib/
+#!/usr/bin/perl
 ##
 ## largeprimes -- generates large provable primes, uniformally distributed
 ##                in random intervals, with maurer's recursive algorithm.

--- a/t/genprime.t
+++ b/t/genprime.t
@@ -8,8 +8,6 @@
 ##
 ## $Id$
 
-use lib '../lib';
-use lib 'lib';
 use Crypt::Primes qw(maurer); 
 use Math::Pari qw(floor);
 

--- a/t/genprime_elgamal.t
+++ b/t/genprime_elgamal.t
@@ -8,8 +8,6 @@
 ##
 ## $Id$
 
-use lib '../lib';
-use lib 'lib';
 use Crypt::Primes; 
 use Math::Pari qw(floor);
 

--- a/t/intermediates.t
+++ b/t/intermediates.t
@@ -8,7 +8,6 @@
 ##
 ## $Id$
 
-use lib qw(../lib);
 use strict;
 use Test;
 


### PR DESCRIPTION
    Once that binary is installed it should rely on Perl
    INC locations to load the libraries needed.

    Otherwise you might load files from unpredictable PATH.